### PR TITLE
:bug:Fix: articles 전반적 오류 수정 #3 #4 #5 #7

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -6,24 +6,25 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 
 
 class Article(models.Model):
-
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     title = models.CharField("제목", max_length=50)
     content = models.TextField("내용")
-    image = models.ImageField("이미지", upload_to='%Y/%m/')
+    image = models.ImageField("이미지", upload_to="%Y/%m/", blank=True)
     created_at = models.DateTimeField("생성 시간", auto_now_add=True)
     updated_at = models.DateTimeField("수정 시간", auto_now=True)
-    likes = models.ManyToManyField(
-        User, related_name='like_articles', blank=True)
+    likes = models.ManyToManyField(User, related_name="like_articles", blank=True)
     stars = models.PositiveIntegerField(
-        '별점', validators=[MaxValueValidator(5), MinValueValidator(1)])
+        "별점", validators=[MaxValueValidator(5), MinValueValidator(1)]
+    )
 
     def __str__(self):
         return self.title
 
 
 class Comment(models.Model):
-    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    article = models.ForeignKey(
+        Article, on_delete=models.CASCADE, related_name="comments"
+    )
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     content = models.CharField("내용", max_length=50)
     created_at = models.DateTimeField("생성 시간", auto_now_add=True)

--- a/articles/serializers.py
+++ b/articles/serializers.py
@@ -1,10 +1,23 @@
 from rest_framework import serializers
 from .models import Article, Comment
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    # UserSerializer 있다고 가정
+    # user = User
+
+    class Meta:
+        model = Comment
+        exclude = ("article", "created_at")
+
+
+class CommentCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ("content",)
+
+
 # from users.models import User
-
-
-
-
 class ArticleListSerializer(serializers.ModelSerializer):
     # user,like = something.serializer
     class Meta:
@@ -20,8 +33,8 @@ class ArticleListSerializer(serializers.ModelSerializer):
             "updated_at",
         )
 
-class ArticleCreateSerializer(serializers.ModelSerializer):
 
+class ArticleCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = ("title", "content", "stars", "image")  # user는 제외!
@@ -29,36 +42,17 @@ class ArticleCreateSerializer(serializers.ModelSerializer):
 
 class ArticleDetailSerializer(serializers.ModelSerializer):
     user = serializers.SerializerMethodField()
-    # comment 불러오는 건 comment 시리얼라이저 만들어지면 수정!
-    # comments = 코멘트시리얼라이저(many=True)
+    comments = CommentSerializer(many=True)
     likes_num = serializers.SerializerMethodField()
 
     # user를 user_id로 보여줌
     def get_user(self, obj):
         return obj.user.user_id
-    
+
     # 현재 게시글의 좋아요 갯수 들고오기
-    # 좋아요 갯수가 아닌 유저 목록으로 보고 싶으면
-    # likes_num을 likes = serializers.StringRelatedField(many=True) 으로 바꿔주기
     def get_likes_num(self, obj):
         return obj.likes.count()
 
     class Meta:
         model = Article
         fields = "__all__"
-
-
-# serializer 추가
-class CommentSerializer(serializers.ModelSerializer):
-    # UserSerializer 있다고 가정
-    # user = User
-
-    class Meta:
-        model = Comment
-        exclude = ("article", "created_at")
-
-
-class CommentCreateSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Comment
-        fields = ("content",)

--- a/articles/urls.py
+++ b/articles/urls.py
@@ -15,10 +15,10 @@ urlpatterns = [
     ),
     path("<int:article_id>/like/", views.LikeView.as_view(), name="like_view"),
     path(
-        "comments/", views.CommentView.as_view(), name="comment_view"
+        "<int:article_id>/comments/", views.CommentView.as_view(), name="comment_view"
     ),
     path(
-        "comments/<int:comment_id>/",
+        "<int:article_id>/comments/<int:comment_id>/",
         views.CommentDetailView.as_view(),
         name="comment_view",
     ),

--- a/articles/views.py
+++ b/articles/views.py
@@ -3,7 +3,7 @@ from rest_framework import status, permissions
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.generics import get_object_or_404
-from articles.models import Article
+from articles.models import Article, Comment
 from .serializers import (
     CommentCreateSerializer,
     CommentSerializer,
@@ -97,7 +97,7 @@ class LikeView(APIView):
         # 게시글 가져오기
         article = get_object_or_404(Article, id=article_id)
         # 현재 로그인 된 유저가 좋아요가 눌러져 있을 경우
-        if request.user in article.likes.all():
+        if request.user.id in article.likes.all():
             # 좋아요를 취소
             article.likes.remove(request.user)
             return Response("좋아요를 취소했습니다.", status=status.HTTP_200_OK)
@@ -129,7 +129,7 @@ class CommentView(APIView):
 
 class CommentDetailView(APIView):
     def put(self, request, article_id, comment_id):
-        comment = Article.objects.get(pk=comment_id)
+        comment = Comment.objects.get(pk=comment_id)
         if request.user == comment.user:
             serializer = CommentCreateSerializer(comment, data=request.data)
             if serializer.is_valid():
@@ -141,7 +141,7 @@ class CommentDetailView(APIView):
             return Response("권한이 없습니다!", status=status.HTTP_403_FORBIDDEN)
 
     def delete(self, request, article_id, comment_id):
-        comment = get_object_or_404(Article, pk=comment_id)
+        comment = get_object_or_404(Comment, pk=comment_id)
         if request.user == comment.user:
             comment.delete()
             return Response("삭제완료", status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
23.05.11.
1. articles/models.py : Comment 하위의 article의 related_name 추가
Article 하위의 image에 blank=True로 수정해 필수값 아니도록 수정

2. articles/serializers.py : Comment관련 serializer들 위치 위로 조정해서 Article의 serializer에 연동 가능하게 함
ArticleDetailSerializer 하위에 comments 추가

3. articles/urls.py : comment 관련 url 앞쪽에 <int:article_id> 추가

4. articles/views.py : LikeView id 잘 연동되지 않던 문제 수정
CommentDetailView에 모델 연결이 잘못 되어있던 것 수정